### PR TITLE
Desabilitando modo resctrito

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
+    "strict": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,


### PR DESCRIPTION
Desabilitando modo resctrito.
- Para evitar erros de compilação por causa do modo restrito, o recomendado é desabilitá-lo no projeto.